### PR TITLE
Fix markdown format for headings in a few files.

### DIFF
--- a/KnowledgeBase/AutoResponder.md
+++ b/KnowledgeBase/AutoResponder.md
@@ -8,15 +8,15 @@ position: 9
 
 <!-- http://fiddler2.com/Fiddler2/help/AutoResponder.asp -->
 
-#AutoResponder Reference
+# AutoResponder Reference
 
 Fiddler's AutoResponder tab allows you to return files from your local disk instead of transmitting the request to the server.
 
-##Creating AutoResponder Rules
+## Creating AutoResponder Rules
 
 On the AutoResponder tab, you enter a **match rule** and an **action string**, and Fiddler will undertake the action if the request URI matches the match rule.
 
-###Tips
+### Tips
 
 * Rules are applied in the order that they appear. Hit the **Plus key** to promote a rule to earlier in the list. Hit the **Minus key** to demote a rule to later in the list.
 * From the context menu, you can **Export a .FARX** file which contains a list of rules and actions.
@@ -24,9 +24,9 @@ On the AutoResponder tab, you enter a **match rule** and an **action string**, a
 * You can or drag-drop sessions from the **Web Sessions** list to replay previous responses. You can edit a rule's stored response by selecting the rule and hitting Enter.
 * You can also drag & drop files from **Windows Explorer** to automatically generate AutoResponder Rules for those files.
 
-##Matching Rules
+## Matching Rules
 
-###String Literals
+### String Literals
 
 Fiddler will match string literals (case insensitively)
 
@@ -34,24 +34,24 @@ Fiddler will match string literals (case insensitively)
 * **http://www.example.com/Path1/query=example**
 * **http://www.example.com/SomethingCompletelyDifferent**
 
-####**EXAMPLE** matches
+#### **EXAMPLE** matches
 * http://www.**example**.com/Path1/
 * http://www.something.com/Path1/query=**Example**
 
-####**path1/** matches
+#### **path1/** matches
 * http://www.example.com/**Path1/**query=example
 * http://www.example.com/returnUrl=**Path1/**OtherPlace
 
-####**query** matches
+#### **query** matches
 
 * http://www.example.com/Path1/q=**Query**
 * http://www.example.com/Path1/**query**=hello
 
-###NOT: rules for String Literals
+### NOT: rules for String Literals
 
 Introduced in version 2.3.2.5 similar to the previous, but the rule is applied only if the string does not match
 
-#### **NOT:EXAMPLE** matches 
+#### **NOT:EXAMPLE** matches
 * http://www.test.com/Path1/query=test
 
 #### **NOT:path1/** matches
@@ -60,95 +60,95 @@ Introduced in version 2.3.2.5 similar to the previous, but the rule is applied o
 #### **NOT:query** matches
 * http://www.example.com/Path1/q
 
-###Exact Match
+### Exact Match
 
 Fiddler supports an exact, case-sensitive match syntax for expressions which begin with exact
 
-####**EXACT:http://www.example.com/path** matches
+#### **EXACT:http://www.example.com/path** matches
 * http://www.example.com/path
 
-####**EXACT:http://www.example.com/path** matches
+#### **EXACT:http://www.example.com/path** matches
 * http://www.example.com/Path (No Match - mismatched case)
 
-####**EXACT:http://www.example.com/path** matches
+#### **EXACT:http://www.example.com/path** matches
 * http://www.example.com/path/q=Query** (No Match - substring different)
 
-###Regular Expressions
+### Regular Expressions
 
 Fiddler supports regular expression syntax for expressions which begin with **regex**. The regular expression will be used to replace the inbound URL with the string in the Actions column. Use .+ to match a sequence of one or more characters, or .* to match zero or more characters. Use ^ at the front of your regex to mean "Start of the URL" and use $ at the tail of the regex to mean "End of the URL."
 
-####**regex:.+** matches
+#### **regex:.+** matches
 * **http://www.example.com/Path1/query=example**
 
-####**regex:.+\.jpg.** matches
+#### **regex:.+\.jpg.** matches
 * **http://www.example.com/Path1/query=foo.jpg**&bar
 * **http://www.example.com/Path1/query=example.jpg**
 
-####**regex:.+\.jpg$** matches
+#### **regex:.+\.jpg$** matches
 * http://www.example.com/Path1/query=foo.jpg&bar (No Match - improper ending)
 * **http://www.example.com/Path1/query=example.jpg**
 
-####**regex:.+\.(jpg|gif|bmp)$** matches 
+#### **regex:.+\.(jpg|gif|bmp)$** matches
 * http://www.example.com/Path1/query=foo.bmp&bar (No Match  - improper ending)
 * **http://www.example.com/Path1/query=example.gif**
 * http://www.example.com/Path1/query=example.Gif  (No Match - mismatched case)
 * **http://www.example.com/Path1/query=example.bmp**
 
-####**regex:(?insx).+\.(jpg|gif|bmp)$**	matches
+#### **regex:(?insx).+\.(jpg|gif|bmp)$**	matches
 * http://www.example.com/Path1/query=foo.bmp&bar (No Match - improper ending)
 * **http://www.example.com/Path1/query=example.gif**
 * **http://www.example.com/Path1/query=example.Gif**
 * **http://www.example.com/Path1/query=example.bmp**
- 	
+
 Got a great regular expression to share?  Please send it to me using the "Contact" link at the top-right side of this page!
 You can learn more about regular expressions [here](http://www.regular-expressions.info/quickstart.html).
 
 You can specify regular expression options (like case-sensitivity) by leading the expression with an appropriate declaration.  (?insx) works well; it turns on case-insensitivity, requires explicit capture groups, enables single-line syntax, and enables comments after the #character. [Learn more on MSDN](https://msdn.microsoft.com/en-us/library/yd1hzczs(VS.80).aspx).
 
-##Actions
+## Actions
 
 Beyond simply returning files, the AutoResponder can also perform special actions...
 
-###filename	
+### filename
 Return contents of filename as the response.
 
-###http://targetURL	
+### http://targetURL
 Return the contents of the targetURL as the response
 
-###*redir:http://targetURL	
+### *redir:http://targetURL
 Return a HTTP Redirect to the target URL. Unlike the simple URL rule, this ensures that the client knows where its request is going so proper cookies are sent, etc.
 
-###*bpu	
+### *bpu
 Break on request before hitting server. Non-final action.
 
-###*bpafter	
+### *bpafter
 Send request to server and break on the response. Non-final action.
 
-###*delay:\#\#\#\#	
+### *delay:\#\#\#\#
 Delay sending request to the server by #### of milliseconds. Non-final action.
 
-###*header:Name=Value	
+### *header:Name=Value
 Set the Request header with the given Name to the specfied value. If no header of that name exists, a new header will be created. Non-final action.
 
-###*flag:Name=Value	
+###*flag:Name=Value
 Set the [Session Flag](./SessionFlags) with the given Name to the specfied value. If no header of that name exists, a new header will be created. Non-final action.
 
-###*CORSPreflightAllow	
+### *CORSPreflightAllow
 Returns a response that indicates that [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) is allowed.
 
-###*reset
+### *reset
 Reset the client connection immediately using a TCP/IP RST to the client.
 
-###*drop
+### *drop
 Close the client connection immediately without sending a response.
 
-###*exit
-Stop processing rules at this point. 
-	
+### *exit
+Stop processing rules at this point.
+
 For rules whose match action is a regular expression, you can use Regular Expression Replacement Group expressions in the Action string to copy content from the Inbound URL to the action string. [Learn more...](https://blogs.msdn.com/b/fiddler/archive/2012/01/09/fiddler-2.3.8.2-beta-views-woff-mp3-h264-datauris-and-autoresponder-supports-regular-expression-groups.aspx)
 
 Rules with Non-final actions will allow the request to match multiple AutoResponder rules. As soon a rule specifying a final action is reached, the matching process exits and no further rules are processed for that session.
 
-##Latency
+## Latency
 
 You can optionally induce a delay (latency) before a response is returned. To enable Latency, click the **Enable Latency** checkbox. Right-click one or more rules and choose **Set Latency** to set the desired number of milliseconds. If you wish to adjust the existing latency, simply type a plus or minus before the number of milliseconds. For instance, to reduce the latency for all of the selected sessions by 5 milliseconds, enter **-5** in the prompt.

--- a/KnowledgeBase/FiddlerArchitecture.md
+++ b/KnowledgeBase/FiddlerArchitecture.md
@@ -8,14 +8,14 @@ position: 12
 
 <!-- http://fiddler2.com/Fiddler/dev/FiddlerArchitecture.asp -->
 
-#Fiddler Architecture Info
+# Fiddler Architecture Info
 
 This page contains information about Fiddler's internal architecture which may be of interest for advanced users of Fiddler. Note that all information presented here is subject to change; expect that you will need to maintain your code if you use the functionality on this page.
 
-##Session State
+## Session State
 The Session.state property exposes information about the current request
 
-		public enum SessionStates 
+		public enum SessionStates
 		{
 		  Created,                   // Object created but nothing's happening yet
 		  ReadingRequest,            // Thread is reading the HTTP Request
@@ -32,13 +32,13 @@ The Session.state property exposes information about the current request
 		  Aborted                    // Session was aborted (client didn't want response, fatal error, etc)
 		};
 
-##FiddlerApplication
-The static **FiddlerApplication** object collects interesting objects and event handlers useful for building extensions. 
+## FiddlerApplication
+The static **FiddlerApplication** object collects interesting objects and event handlers useful for building extensions.
 
 		public delegate void SimpleEventHandler();
 		public delegate void CalculateReportHandler(Session[] _arrSessions);
 
-		public class FiddlerApplication 
+		public class FiddlerApplication
 		{
 		  [CodeDescription("Fiddler's main form.")]
 		  public static frmViewer UI;
@@ -59,7 +59,7 @@ The static **FiddlerApplication** object collects interesting objects and event 
 
 		  [CodeDescription("FiddlerScript scripting engine.")]   Likely to be removed
 		  public static FiddlerScript scriptRules;
-		  
+
 		  [CodeDescription("Sync this event to be notified when Fiddler has completed startup.")]
 		  public static event SimpleEventHandler FiddlerBoot;
 
@@ -68,33 +68,33 @@ The static **FiddlerApplication** object collects interesting objects and event 
 
 		  [CodeDescription("Sync this event to be notified when Fiddler has detached as the system proxy.")]
 		  public static event SimpleEventHandler FiddlerDetach;
-		  
+
 		  [CodeDescription("Sync this event to be notified when Fiddler shuts down.")]
 		  public static event SimpleEventHandler FiddlerShutdown;
-		  
+
 		  [CodeDescription("Sync this event to capture the CalculateReport event, summarizing the selected sessions.")]
 		  public static event CalculateReportHandler CalculateReport;
 		}
 
-##Fiddler SessionFlags
+## Fiddler SessionFlags
 Each Session object in Fiddler contains a collection of string flags, in the Session.oFlags[] collection.  The flags control how the session is processed and displayed in Session List. See [Fiddler Session Flags](http://fiddler2.com/Fiddler/dev/SessionFlags.asp) for more information.
 
-##SessionTimers
+## SessionTimers
 As it processes each Session, Fiddler keeps track of key events using the .Timers object on each session. You can learn more about [what each SessionTimer means](http://fiddler.wikidot.com/Timers).
 
-##About Fiddler's sources
+## About Fiddler's sources
 According to [this line count tool](http://www.codeproject.com/useritems/LineCountUtility.asp), the main Fiddler project consists of ~23k lines of C# code, after many recent refactorings to simplify the code.
 
 The default Inspector objects contain ~6k lines of code, and the FiddlerExtensions (RulesTab, RulesTab2, GalleryView, TimelineView) contain ~2k lines of code.
 
 As you can see, coding against the .NET Framework offers a lot of power per line of code.
 
-##HTTPS Protocol Support
-By default, Fiddler2 accepts SSLv2 SSLv3 and TLSv1 from the client, and offers SSLv3 and TLSv1 to the server. The text in the response for the CONNECT tunnel shows what cipher the remote server chose, and shows information about the server's certificate. 
+## HTTPS Protocol Support
+By default, Fiddler2 accepts SSLv2 SSLv3 and TLSv1 from the client, and offers SSLv3 and TLSv1 to the server. The text in the response for the CONNECT tunnel shows what cipher the remote server chose, and shows information about the server's certificate.
 
 Note that this may be different than if Fiddler were not intercepting the connection.  If you want to see what algorithms would have been chosen had Fiddler not been involved, disable the Decrypt HTTPS Traffic feature using the Tools | Fiddler Options menu.
 
 Learn more about [HTTPS Decryption](../Configure-Fiddler/Tasks/DecryptHTTPS).
 
-##Silent Installation
+## Silent Installation
 Want a silent / unattended install?  Use the setup command line: **FiddlerSetup.exe /S**

--- a/KnowledgeBase/HTTP.md
+++ b/KnowledgeBase/HTTP.md
@@ -8,13 +8,13 @@ position: 11
 
 <!-- http://www.fiddler2.com/Fiddler/help/http/ -->
 
-#HTTP References
+# HTTP References
 
-##RFCs
+## RFCs
 * [HTTP Response codes (RFC 2616)](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) and [HTTP Response Codes (Wikipedia)](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
 * [HTTP Header Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)
 * [HTTP 1.1 Specification (RFC 2616)](http://www.rfc-editor.org/rfc/rfc2616.txt)
 
-##Other Useful specs
+## Other Useful specs
 * [Unicode and Character Sets](http://www.joelonsoftware.com/articles/Unicode.html)
 * [Regular Expressions Tutorial](http://www.regular-expressions.info/)

--- a/KnowledgeBase/OptionsUI.md
+++ b/KnowledgeBase/OptionsUI.md
@@ -8,9 +8,9 @@ position: 6
 
 <!-- http://fiddler2.com/Fiddler/help/OptionsUI.asp -->
 
-#Fiddler Options
+# Fiddler Options
 
-##General
+## General
 * **Check for updates on startup** controls whether Fiddler will contact the version-checking web service on startup.
 * **Show a message when HTTP protocol violations encountered** controls whether Fiddler notifies you if it observes HTTP protocol violations.
 * **Enable IPv6** controls whether or not Fiddler will connect to HTTP servers using IPv6, if available.
@@ -19,25 +19,25 @@ position: 6
 * **Automatically stream audio & video** controls whether Fiddler will use [streaming mode](http://fiddler2.com/Fiddler/help/streaming.asp) when downloading audio and video content-types.
 * The **Systemwide Hotkey** checkbox permits you to pick a hotkey which will restore and activate Fiddler when it is inactive or minimized.
 
-##HTTPS
+## HTTPS
 * **Capture HTTPS CONNECTs** controls whether Fiddler will attempt to create tunnels through which secure traffic will flow.
 * **Decrypt HTTPS traffic** controls whether Fiddler will [decrypt](http://www.fiddler2.com/redir/?id=HTTPSDECRYPTION) the requests and responses within those secure tunnels.
 * **Ignore server certificate errors** controls whether Fiddler will warn you if an HTTPS server has presented a certificate that did not validate.  You should not check this box when surfing the Internet due to the spoofing security threat.
 * *Show data from RPASpy controls whether or not Fiddler will show HTTPS headers reported by the deprecated [RPASpy addon.](http://www.fiddler2.com/redir/?id=RPASPY)*
 
-##Extensions
+## Extensions
 * **Automatically reload script when changed** controls whether or not Fiddler will automatically reload the FiddlerScript rules file when it detects that the file has been changed.
 * The **Editor** text box allows you to control which text editor is used to edit the FiddlerScript.  The "..." button will launch a dialog to allow selection of the editor. The [FiddlerScriptEditor](http://fiddler2.com/fiddler/fse.asp) is a popular choice.
 * The References text box allows you to specify any additional assemblies that your FiddlerScript depends upon.
 * The **Find more extensions** link opens the [Fiddler Add-ons page.](http://www.fiddler2.com/redir/?id=FIDDLEREXTENSIONS)
 
-##Connections
+## Connections
 * The **Fiddler listens on port** textbox controls which port Fiddler uses to listen for web traffic.
 * The **Copy Browser Proxy Config URL** link copies a proxy-configuration-script link that you can paste into a client's proxy configuration screen. This option is rarely useful, but learn more [here.](../Configure-Fiddler/Tasks/ConfigureBrowsers)
 * **Allow remote computers to connect** controls whether or not Fiddler will accept HTTP requests from other computers.
 * **Reuse client connections** controls whether Fiddler will reuse HTTP client connections (keep-alive).
 * **Reuse connections to servers** controls whether Fiddler will reuse HTTP server connections (keep-alive).
-* The **Chain to upstream gateway proxy** controls whether or not Fiddler will use the system proxy as an upstream gateway proxy.  
+* The **Chain to upstream gateway proxy** controls whether or not Fiddler will use the system proxy as an upstream gateway proxy.
 
 By unchecking this checkbox, you're telling Fiddler *"ignore my browser's normal proxy settings, and just send requests directly to web servers."*
 
@@ -48,7 +48,7 @@ By unchecking this checkbox, you're telling Fiddler *"ignore my browser's normal
 * The **WinINET Connections** list shows what network connections are configured for this machine.  This may be useful if you are connected to the Internet via dialup or VPN and want Fiddler to automatically hook a connection other than your LAN connection. [Learn more...](../Configure-Fidder/Tasks/MonitorDialupAndVPN)
 * The **IE should bypass Fiddler** list controls which requests should not be sent through Fiddler at all when it is registered as the system proxy.  Note that this list is generally only respected by WinINET clients like Internet Explorer.
 
-##Appearance
+## Appearance
 * The **Font Size** box allows you to select the font-size Fiddler will use.  A restart is required to fully complete the change.
 * The **Set Readonly Color** button allows you to select the background color for text boxes which are in a readonly state. This setting primarily exists because gray is the default for Windows and gray is kinda ugly. A restart is required to complete this change.
 * The **Hide Fiddler when minimized** checkbox will show the Fiddler icon in your system tray rather than the task bar when Fiddler is minimized.

--- a/KnowledgeBase/VPAT.md
+++ b/KnowledgeBase/VPAT.md
@@ -6,46 +6,46 @@ publish: true
 ---
 
 
-###Date:
+### Date:
 9/15/2012
 
-###Name of Product:
+### Name of Product:
 Fiddler Web Debugger
 
-###Contact for more Information:
+### Contact for more Information:
 [http://www.fiddler2.com](http://www.fiddler2.com/)
 
-#Summary
-##Voluntary Product Accessibility Template
+# Summary
+## Voluntary Product Accessibility Template
 
-###Section 1194.21 Software Applications and Operating Systems
+### Section 1194.21 Software Applications and Operating Systems
 Please refer to the attached VPAT
 
-###Section 1194.22 Web-based Internet Information and Applications
+### Section 1194.22 Web-based Internet Information and Applications
 Not Applicable - Fiddler is not considered a web-based internet information application
 
-###Section 1194.23 Telecommunications Products
+### Section 1194.23 Telecommunications Products
 Not Applicable - Fiddler is not considered a telecommunications product
 
-###Section 1194.24 Video and Multi-media Products
+### Section 1194.24 Video and Multi-media Products
 Not Applicable - Fiddler is not considered a video or multi-media product
 
-###Section 1194.25 Self-Contained, Closed Products
+### Section 1194.25 Self-Contained, Closed Products
 Not Applicable - Fiddler is not considered a self-contained, closed product
 
-###Section 1194.26 Desktop and Portable Computers
+### Section 1194.26 Desktop and Portable Computers
 Not Applicable - Fiddler is not considered a desktop or portable computer
 
-###Section 1194.31 Functional Performance Criteria
+### Section 1194.31 Functional Performance Criteria
 Please refer to the attached VPAT
 
-###Section 1194.41 Information, Documentation, and Support
+### Section 1194.41 Information, Documentation, and Support
 Please refer to the attached VPAT
 
-#Section 1194.21 Software Applications and Operating Systems - Detail
-##Voluntary Product Accessibility Template
+# Section 1194.21 Software Applications and Operating Systems - Detail
+## Voluntary Product Accessibility Template
 
-###(a) When software is designed to run on a system that has a keyboard, product functions shall be executable from a keyboard where the function itself or the result of performing a function can be discerned textually.
+### (a) When software is designed to run on a system that has a keyboard, product functions shall be executable from a keyboard where the function itself or the result of performing a function can be discerned textually.
 Supports with Exceptions
 
 * Fiddler supports all standard keyboard features of the user interface.
@@ -58,249 +58,249 @@ Exceptions
 * Fiddler supports all standard keyboard operation of the user interface.
 * Fiddler plugins not bundled with Fiddler may or may not support keyboard accessibility.
 
-###(b) Applications shall not disrupt or disable activated features of other products that are identified as accessibility features, where those features are developed and documented according to industry standards. Applications also shall not disrupt or disable activated features of any operating system that are identified as accessibility features where the application programming interface for those accessibility features has been documented by the manufacturer of the operating system and is available to the product developer.
+### (b) Applications shall not disrupt or disable activated features of other products that are identified as accessibility features, where those features are developed and documented according to industry standards. Applications also shall not disrupt or disable activated features of any operating system that are identified as accessibility features where the application programming interface for those accessibility features has been documented by the manufacturer of the operating system and is available to the product developer.
 Supports with Exceptions
 
 * Fiddler supports system StickyKeys, FilterKeys, MouseKeys, SerialKeys and ToggleKeys.
 
-###(c) A well-defined on-screen indication of the current focus shall be provided that moves among interactive interface elements as the input focus changes. The focus shall be programmatically exposed so that Assistive Technology can track focus and focus changes.
+### (c) A well-defined on-screen indication of the current focus shall be provided that moves among interactive interface elements as the input focus changes. The focus shall be programmatically exposed so that Assistive Technology can track focus and focus changes.
 Supports with Exceptions
 
 * Fiddler indicates focus in all focusable fields using standard technologies.
 
-###(d) Sufficient information about a user interface element including the identity, operation and state of the element shall be available to Assistive Technology. When an image represents a program element, the information conveyed by the image must also be available in text.
+### (d) Sufficient information about a user interface element including the identity, operation and state of the element shall be available to Assistive Technology. When an image represents a program element, the information conveyed by the image must also be available in text.
 Supports with Exceptions
 
 * Fiddler user interface elements are exposed programmatically through managed object models and programming interfaces such as Microsoft Active Accessibility. Standard Windows controls and interface elements automatically expose this information through Microsoft Active Accessibility.
 
-###(e) When bitmap images are used to identify controls, status indicators, or other programmatic elements, the meaning assigned to those images shall be consistent throughout an application's performance.
+### (e) When bitmap images are used to identify controls, status indicators, or other programmatic elements, the meaning assigned to those images shall be consistent throughout an application's performance.
 Supports
 
 * Fiddler utilizes standard and consistent images throughout.
 
-###(f) Textual information shall be provided through operating system functions for displaying text. The minimum information that shall be made available is text content, text input caret location, and text attributes.
+### (f) Textual information shall be provided through operating system functions for displaying text. The minimum information that shall be made available is text content, text input caret location, and text attributes.
 Supports with Exceptions
 
 * Fiddler provides textual information through Microsoft Active Accessibility.
 * Microsoft Active Accessibility is a COM-based technology that improves the way accessibility aids work with applications running on Microsoft Windows operating systems. It provides dynamic-link libraries that are incorporated into the operating system, as well as a COM interface and application programming elements that provide reliable methods for exposing information about user interface elements.
 
-###(g) Applications shall not override user selected contrast and color selections and other individual display attributes.
+### (g) Applications shall not override user selected contrast and color selections and other individual display attributes.
 Supports with Exceptions
 
 * In some cases, Fiddler overrides UI colors to indicate characteristics of HTTP/HTTPS traffic.  Color is not used as the sole distinguishing attribute.
 * Fiddler does not always respect system font sizing.  Fiddler font sizing may be controlled from the Tools / Fiddler Options screen.
 
-###(h) When animation is displayed, the information shall be displayable in at least one non-animated presentation mode at the option of the user.
+### (h) When animation is displayed, the information shall be displayable in at least one non-animated presentation mode at the option of the user.
 Supports with Exceptions
 
 * Fiddler does not use animation in its user interface.
 * When viewing animated web images using Fiddler, they will be animated.
 
-###(i) Color coding shall not be used as the only means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.
+### (i) Color coding shall not be used as the only means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.
 Supports
 
 * Fiddler does not use colors as the only way to convey information, indicate an action, prompt a response, or distinguish a visual element.
 
-###(j) When a product permits a user to adjust color and contrast settings, a variety of color selections capable of producing a range of contrast levels shall be provided.
+### (j) When a product permits a user to adjust color and contrast settings, a variety of color selections capable of producing a range of contrast levels shall be provided.
 Supports
 
 * Fiddler supports changing of UI element colors via its scripting engine.
 
-###(k) Software shall not use flashing or blinking text, objects, or other elements having a flash or blink frequency greater than 2 Hz and lower than 55 Hz.
+### (k) Software shall not use flashing or blinking text, objects, or other elements having a flash or blink frequency greater than 2 Hz and lower than 55 Hz.
 Supports with Exceptions
 
 * When viewing animated web images using Fiddler, they will be animated according to the original images settings.
 
 
-###(l) When electronic forms are used, the form shall allow people using Assistive Technology to access the information, field elements, and functionality required for completion and submission of the form, including all directions and cues.
+### (l) When electronic forms are used, the form shall allow people using Assistive Technology to access the information, field elements, and functionality required for completion and submission of the form, including all directions and cues.
 Not Applicable
 
 * Fiddler does not use electronic forms.
 
-#Section 1194.22 Web-based Internet Information and Applications - Detail
-##Voluntary Product Accessibility Template
+# Section 1194.22 Web-based Internet Information and Applications - Detail
+## Voluntary Product Accessibility Template
 
-###(a) A text equivalent for every non-text element shall be provided (e.g., via "alt", "longdesc", or in element content).
+### (a) A text equivalent for every non-text element shall be provided (e.g., via "alt", "longdesc", or in element content).
 Not Applicable
 
-###(b) Equivalent alternatives for any multimedia presentation shall be synchronized with the presentation.
+### (b) Equivalent alternatives for any multimedia presentation shall be synchronized with the presentation.
 Not Applicable
 
-###(c) Web pages shall be designed so that all information conveyed with color is also available without color, for example from context or markup.
+### (c) Web pages shall be designed so that all information conveyed with color is also available without color, for example from context or markup.
 Not Applicable
 
-###(d) Documents shall be organized so they are readable without requiring an associated style sheet.
+### (d) Documents shall be organized so they are readable without requiring an associated style sheet.
 Not Applicable
 
-###(e) Redundant text links shall be provided for each active region of a server-side image map.
+### (e) Redundant text links shall be provided for each active region of a server-side image map.
 Not Applicable
 
-###(f) Client-side image maps shall be provided instead of server-side image maps except where the regions cannot be defined with an available geometric shape.
+### (f) Client-side image maps shall be provided instead of server-side image maps except where the regions cannot be defined with an available geometric shape.
 Not Applicable
 
-###(g) Row and column headers shall be identified for data tables.
+### (g) Row and column headers shall be identified for data tables.
 Not Applicable
 
-###(h) Markup shall be used to associate data cells and header cells for data tables that have two or more logical levels of row or column headers.
+### (h) Markup shall be used to associate data cells and header cells for data tables that have two or more logical levels of row or column headers.
 Not Applicable
 
-###(i) Frames shall be titled with text that facilitates frame identification and navigation
+### (i) Frames shall be titled with text that facilitates frame identification and navigation
 Not Applicable
 
-###(j) Pages shall be designed to avoid causing the screen to flicker with a frequency greater than 2 Hz and lower than 55 Hz.
+### (j) Pages shall be designed to avoid causing the screen to flicker with a frequency greater than 2 Hz and lower than 55 Hz.
 Not Applicable
 
-###(k) A text-only page, with equivalent information or functionality, shall be provided to make a web site comply with the provisions of this part, when compliance cannot be accomplished in any other way. The content of the text-only page shall be updated whenever the primary page changes.
+### (k) A text-only page, with equivalent information or functionality, shall be provided to make a web site comply with the provisions of this part, when compliance cannot be accomplished in any other way. The content of the text-only page shall be updated whenever the primary page changes.
 Not Applicable
 
-###(l) When pages utilize scripting languages to display content, or to create interface elements, the information provided by the script shall be identified with functional text that can be read by Assistive Technology.
+### (l) When pages utilize scripting languages to display content, or to create interface elements, the information provided by the script shall be identified with functional text that can be read by Assistive Technology.
 Not Applicable
 
-###(m) When a web page requires that an applet, plug-in or other application be present on the client system to interpret page content, the page must provide a link to a plug-in or applet that complies with §1194.21(a) through (l).
+### (m) When a web page requires that an applet, plug-in or other application be present on the client system to interpret page content, the page must provide a link to a plug-in or applet that complies with §1194.21(a) through (l).
 Not Applicable
 
-###(n) When electronic forms are designed to be completed on-line, the form shall allow people using Assistive Technology to access the information, field elements, and functionality required for completion and submission of the form, including all directions and cues.
+### (n) When electronic forms are designed to be completed on-line, the form shall allow people using Assistive Technology to access the information, field elements, and functionality required for completion and submission of the form, including all directions and cues.
 Not Applicable
 
-###(o) A method shall be provided that permits users to skip repetitive navigation links.
+### (o) A method shall be provided that permits users to skip repetitive navigation links.
 Not Applicable
 
-###(p) When a timed response is required, the user shall be alerted and given sufficient time to indicate more time is required.
+### (p) When a timed response is required, the user shall be alerted and given sufficient time to indicate more time is required.
 Not Applicable
 
-#Section 1194.23 Telecommunications Products - Detail
-##Voluntary Product Accessibility Template
+# Section 1194.23 Telecommunications Products - Detail
+## Voluntary Product Accessibility Template
 
-###(a) Telecommunications products or systems which provide a function allowing voice communication and which do not themselves provide a TTY functionality shall provide a standard non-acoustic connection point for TTYs. Microphones shall be capable of being turned on and off to allow the user to intermix speech with TTY use.
+### (a) Telecommunications products or systems which provide a function allowing voice communication and which do not themselves provide a TTY functionality shall provide a standard non-acoustic connection point for TTYs. Microphones shall be capable of being turned on and off to allow the user to intermix speech with TTY use.
 Not Applicable
 
-###(b) Telecommunications products which include voice communication functionality shall support all commonly used cross-manufacturer non-proprietary standard TTY signal protocols.
+### (b) Telecommunications products which include voice communication functionality shall support all commonly used cross-manufacturer non-proprietary standard TTY signal protocols.
 Not Applicable
 
-###(c) Voice mail, auto-attendant, and interactive voice response telecommunications systems shall be usable by TTY users with their TTYs.
+### (c) Voice mail, auto-attendant, and interactive voice response telecommunications systems shall be usable by TTY users with their TTYs.
 Not Applicable
 
-###(d) Voice mail, messaging, auto-attendant, and interactive voice response telecommunications systems that require a response from a user within a time interval, shall give an alert when the time interval is about to run out, and shall provide sufficient time for the user to indicate more time is required.
+### (d) Voice mail, messaging, auto-attendant, and interactive voice response telecommunications systems that require a response from a user within a time interval, shall give an alert when the time interval is about to run out, and shall provide sufficient time for the user to indicate more time is required.
 Not Applicable
 
-###(e) Where provided, caller identification and similar telecommunications functions shall also be available for users of TTYs, and for users who cannot see displays.
+### (e) Where provided, caller identification and similar telecommunications functions shall also be available for users of TTYs, and for users who cannot see displays.
 Not Applicable
 
-###(f) For transmitted voice signals, telecommunications products shall provide a gain adjustable up to a minimum of 20 dB. For incremental volume control, at least one intermediate step of 12 dB of gain shall be provided.
+### (f) For transmitted voice signals, telecommunications products shall provide a gain adjustable up to a minimum of 20 dB. For incremental volume control, at least one intermediate step of 12 dB of gain shall be provided.
 Not Applicable
 
-###(g) If the telecommunications product allows a user to adjust the receive volume, a function shall be provided to automatically reset the volume to the default level after every use.
+### (g) If the telecommunications product allows a user to adjust the receive volume, a function shall be provided to automatically reset the volume to the default level after every use.
 Not Applicable
 
-###(h) Where a telecommunications product delivers output by an audio transducer which is normally held up to the ear, a means for effective magnetic wireless coupling to hearing technologies shall be provided.
+### (h) Where a telecommunications product delivers output by an audio transducer which is normally held up to the ear, a means for effective magnetic wireless coupling to hearing technologies shall be provided.
 Not Applicable
 
-###(i) Interference to hearing technologies (including hearing aids, cochlear implants, and assistive listening devices) shall be reduced to the lowest possible level that allows a user of hearing technologies to utilize the telecommunications product.
+### (i) Interference to hearing technologies (including hearing aids, cochlear implants, and assistive listening devices) shall be reduced to the lowest possible level that allows a user of hearing technologies to utilize the telecommunications product.
 Not Applicable
 
-###(j) Products that transmit or conduct information or communication, shall pass through cross-manufacturer, non-proprietary, industry-standard codes, translation protocols, formats or other information necessary to provide the information or communication in a usable format. Technologies which use encoding, signal compression, format transformation, or similar techniques shall not remove information needed for access or shall restore it upon delivery.
+### (j) Products that transmit or conduct information or communication, shall pass through cross-manufacturer, non-proprietary, industry-standard codes, translation protocols, formats or other information necessary to provide the information or communication in a usable format. Technologies which use encoding, signal compression, format transformation, or similar techniques shall not remove information needed for access or shall restore it upon delivery.
 Not Applicable
 
-###(k)(1) Products which have mechanically operated controls or keys shall comply with the following: Controls and Keys shall be tactilely discernible without activating the controls or keys.
+### (k)(1) Products which have mechanically operated controls or keys shall comply with the following: Controls and Keys shall be tactilely discernible without activating the controls or keys.
 Not Applicable
 
-###(k)(2) Products which have mechanically operated controls or keys shall comply with the following: Controls and Keys shall be operable with one hand and shall not require tight grasping, pinching, twisting of the wrist. The force required to activate controls and keys shall be 5 lbs. (22.2N) maximum.
+### (k)(2) Products which have mechanically operated controls or keys shall comply with the following: Controls and Keys shall be operable with one hand and shall not require tight grasping, pinching, twisting of the wrist. The force required to activate controls and keys shall be 5 lbs. (22.2N) maximum.
 Not Applicable
 
-###(k)(3) Products which have mechanically operated controls or keys shall comply with the following: If key repeat is supported, the delay before repeat shall be adjustable to at least 2 seconds. Key repeat rate shall be adjustable to 2 seconds per character.
+### (k)(3) Products which have mechanically operated controls or keys shall comply with the following: If key repeat is supported, the delay before repeat shall be adjustable to at least 2 seconds. Key repeat rate shall be adjustable to 2 seconds per character.
 Not Applicable
 
-###(k)(4) Products which have mechanically operated controls or keys shall comply with the following: The status of all locking or toggle controls or keys shall be visually discernible, and discernible either through touch or sound.
+### (k)(4) Products which have mechanically operated controls or keys shall comply with the following: The status of all locking or toggle controls or keys shall be visually discernible, and discernible either through touch or sound.
 Not Applicable
 
-#Section 1194.24 Video and Multimedia Products
-##Voluntary Product Accessibility Template
+# Section 1194.24 Video and Multimedia Products
+## Voluntary Product Accessibility Template
 
-###(a) All analog television displays 13 inches and larger, and computer equipment that includes analog television receiver or display circuitry, shall be equipped with caption decoder circuitry which appropriately receives, decodes, and displays closed captions from broadcast, cable, videotape, and DVD signals. As soon as practicable, but not later than July 1, 2002, widescreen digital television (DTV) displays measuring at least 7.8 inches vertically, DTV sets with conventional displays measuring at least 13 inches vertically, and stand-alone DTV tuners, whether or not they are marketed with display screens, and computer equipment that includes DTV receiver or display circuitry, shall be equipped with caption decoder circuitry which appropriately receives, decodes, and displays closed captions from broadcast, cable, videotape, and DVD signals.
-Not Applicable
-
-* This is a hardware related item that does not apply to Fiddler.
-
-###(b) Television tuners, including tuner cards for use in computers, shall be equipped with secondary audio program playback circuitry.
+### (a) All analog television displays 13 inches and larger, and computer equipment that includes analog television receiver or display circuitry, shall be equipped with caption decoder circuitry which appropriately receives, decodes, and displays closed captions from broadcast, cable, videotape, and DVD signals. As soon as practicable, but not later than July 1, 2002, widescreen digital television (DTV) displays measuring at least 7.8 inches vertically, DTV sets with conventional displays measuring at least 13 inches vertically, and stand-alone DTV tuners, whether or not they are marketed with display screens, and computer equipment that includes DTV receiver or display circuitry, shall be equipped with caption decoder circuitry which appropriately receives, decodes, and displays closed captions from broadcast, cable, videotape, and DVD signals.
 Not Applicable
 
 * This is a hardware related item that does not apply to Fiddler.
 
-###(c) All training and informational video and multimedia productions which support the agency's mission, regardless of format, that contain speech or other audio information necessary for the comprehension of the content, shall be open or closed captioned.
+### (b) Television tuners, including tuner cards for use in computers, shall be equipped with secondary audio program playback circuitry.
+Not Applicable
+
+* This is a hardware related item that does not apply to Fiddler.
+
+### (c) All training and informational video and multimedia productions which support the agency's mission, regardless of format, that contain speech or other audio information necessary for the comprehension of the content, shall be open or closed captioned.
 Does Not Support
 
 * Fiddler demonstration videos [http://www.fiddler2.com/fiddler/help/video/default.asp](http://www.fiddler2.com/fiddler/help/video/default.asp) are not required to use the product, and are not currently closed-captioned.
 
-###(d) All training and informational video and multimedia productions which support the agency's mission, regardless of format, that contain visual information necessary for the comprehension of the content, shall be audio described.
+### (d) All training and informational video and multimedia productions which support the agency's mission, regardless of format, that contain visual information necessary for the comprehension of the content, shall be audio described.
 Does Not Support
 
 * Fiddler demonstration videos [http://www.fiddler2.com/fiddler/help/video/default.asp](http://www.fiddler2.com/fiddler/help/video/default.asp) are not required to use the product, and are not currently closed-captioned.
 * The majority of their content is available in textual form elsewhere in the Help.
 
-###(e) Display or presentation of alternate text presentation or audio descriptions shall be user-selectable unless permanent.
+### (e) Display or presentation of alternate text presentation or audio descriptions shall be user-selectable unless permanent.
 Not Applicable
 
-#Section 1194.25 Self-Contained, Closed Products - Detail
-##Voluntary Product Accessibility Template
+# Section 1194.25 Self-Contained, Closed Products - Detail
+## Voluntary Product Accessibility Template
 
-###(a) Self contained products shall be usable by people with disabilities without requiring an end-user to attach Assistive Technology to the product. Personal headsets for private listening are not Assistive Technology.
+### (a) Self contained products shall be usable by people with disabilities without requiring an end-user to attach Assistive Technology to the product. Personal headsets for private listening are not Assistive Technology.
 Not Applicable
 
-###(b) When a timed response is required, the user shall be alerted and given sufficient time to indicate more time is required.
+### (b) When a timed response is required, the user shall be alerted and given sufficient time to indicate more time is required.
 Not Applicable
 
-###(c) Where a product utilizes touch screens or contact-sensitive controls, an input method shall be provided that complies with §1194.23 (k) (1) through (4).
+### (c) Where a product utilizes touch screens or contact-sensitive controls, an input method shall be provided that complies with §1194.23 (k) (1) through (4).
 Not Applicable
 
-###(d) When biometric forms of user identification or control are used, an alternative form of identification or activation, which does not require the user to possess particular biological characteristics, shall also be provided.
+### (d) When biometric forms of user identification or control are used, an alternative form of identification or activation, which does not require the user to possess particular biological characteristics, shall also be provided.
 Not Applicable
 
-###(e) When products provide auditory output, the audio signal shall be provided at a standard signal level through an industry standard connector that will allow for private listening. The product must provide the ability to interrupt, pause, and restart the audio at anytime.
+### (e) When products provide auditory output, the audio signal shall be provided at a standard signal level through an industry standard connector that will allow for private listening. The product must provide the ability to interrupt, pause, and restart the audio at anytime.
 Not Applicable
 
-###(f) When products deliver voice output in a public area, incremental volume control shall be provided with output amplification up to a level of at least 65 dB. Where the ambient noise level of the environment is above 45 dB, a volume gain of at least 20 dB above the ambient level shall be user selectable. A function shall be provided to automatically reset the volume to the default level after every use.
+### (f) When products deliver voice output in a public area, incremental volume control shall be provided with output amplification up to a level of at least 65 dB. Where the ambient noise level of the environment is above 45 dB, a volume gain of at least 20 dB above the ambient level shall be user selectable. A function shall be provided to automatically reset the volume to the default level after every use.
 Not Applicable
 
-###(g) Color coding shall not be used as the only means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.
+### (g) Color coding shall not be used as the only means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.
 Not Applicable
 
-###(h) When a product permits a user to adjust color and contrast settings, a range of color selections capable of producing a variety of contrast levels shall be provided.
+### (h) When a product permits a user to adjust color and contrast settings, a range of color selections capable of producing a variety of contrast levels shall be provided.
 Not Applicable
 
-###(i) Products shall be designed to avoid causing the screen to flicker with a frequency greater than 2 Hz and lower than 55 Hz.
+### (i) Products shall be designed to avoid causing the screen to flicker with a frequency greater than 2 Hz and lower than 55 Hz.
 Not Applicable
 
-###(j) (1) Products which are freestanding, non-portable, and intended to be used in one location and which have operable controls shall comply with the following: The position of any operable control shall be determined with respect to a vertical plane, which is 48 inches in length, centered on the operable control, and at the maximum protrusion of the product within the 48 inch length on products which are freestanding, non-portable, and intended to be used in one location and which have operable controls.
+### (j) (1) Products which are freestanding, non-portable, and intended to be used in one location and which have operable controls shall comply with the following: The position of any operable control shall be determined with respect to a vertical plane, which is 48 inches in length, centered on the operable control, and at the maximum protrusion of the product within the 48 inch length on products which are freestanding, non-portable, and intended to be used in one location and which have operable controls.
 Not Applicable
 
-###(j)(2) Products which are freestanding, non-portable, and intended to be used in one location and which have operable controls shall comply with the following: Where any operable control is 10 inches or less behind the reference plane, the height shall be 54 inches maximum and 15 inches minimum above the floor.
+### (j)(2) Products which are freestanding, non-portable, and intended to be used in one location and which have operable controls shall comply with the following: Where any operable control is 10 inches or less behind the reference plane, the height shall be 54 inches maximum and 15 inches minimum above the floor.
 Not Applicable
 
-###(j)(3) Products which are freestanding, non-portable, and intended to be used in one location and which have operable controls shall comply with the following: Where any operable control is more than 10 inches and not more than 24 inches behind the reference plane, the height shall be 46 inches maximum and 15 inches minimum above the floor.
+### (j)(3) Products which are freestanding, non-portable, and intended to be used in one location and which have operable controls shall comply with the following: Where any operable control is more than 10 inches and not more than 24 inches behind the reference plane, the height shall be 46 inches maximum and 15 inches minimum above the floor.
 Not Applicable
 
-###(j)(4) Products which are freestanding, non-portable, and intended to be used in one location and which have operable controls shall comply with the following: Operable controls shall not be more than 24 inches behind the reference plane.
+### (j)(4) Products which are freestanding, non-portable, and intended to be used in one location and which have operable controls shall comply with the following: Operable controls shall not be more than 24 inches behind the reference plane.
 Not Applicable
 
-#Section 1194.26 Desktop and Portable Computers - Detail
-##Voluntary Product Accessibility Template
+# Section 1194.26 Desktop and Portable Computers - Detail
+## Voluntary Product Accessibility Template
 
-###(a) All mechanically operated controls and keys shall comply with §1194.23 (k) (1) through (4).
+### (a) All mechanically operated controls and keys shall comply with §1194.23 (k) (1) through (4).
 Not Applicable
 
-###(b) If a product utilizes touch screens or touch-operated controls, an input method shall be provided that complies with §1194.23 (k) (1) through (4).
+### (b) If a product utilizes touch screens or touch-operated controls, an input method shall be provided that complies with §1194.23 (k) (1) through (4).
 Not Applicable
 
-###(c) When biometric forms of user identification or control are used, an alternative form of identification or activation, which does not require the user to possess particular biological characteristics, shall also be provided.
+### (c) When biometric forms of user identification or control are used, an alternative form of identification or activation, which does not require the user to possess particular biological characteristics, shall also be provided.
 Not Applicable
 
-###(d) Where provided, at least one of each type of expansion slots, ports and connectors shall comply with publicly available industry standards
+### (d) Where provided, at least one of each type of expansion slots, ports and connectors shall comply with publicly available industry standards
 Not Applicable
 
-#Section 1194.31 Functional Performance Criteria - Detail
-##Voluntary Product Accessibility Template
+# Section 1194.31 Functional Performance Criteria - Detail
+## Voluntary Product Accessibility Template
 
-###(a) At least one mode of operation and information retrieval that does not require user vision shall be provided, or support for Assistive Technology used by people who are blind or visually impaired shall be provided.
+### (a) At least one mode of operation and information retrieval that does not require user vision shall be provided, or support for Assistive Technology used by people who are blind or visually impaired shall be provided.
 Supports with Exceptions
 
 * Fiddler Supports the use of assistive technology, such as screen readers, for access by people who are blind or visually impaired, except as noted in the Remarks section.
@@ -311,27 +311,27 @@ Exceptions
 
 * Not all available plugins support assistive technologies.
 
-###(b) At least one mode of operation and information retrieval that does not require visual acuity greater than 20/70 shall be provided in audio and enlarged print output working together or independently, or support for Assistive Technology used by people who are visually impaired shall be provided.
+### (b) At least one mode of operation and information retrieval that does not require visual acuity greater than 20/70 shall be provided in audio and enlarged print output working together or independently, or support for Assistive Technology used by people who are visually impaired shall be provided.
 Supports
 
 * Fiddler supports font sizing using the Tools / Fiddler Options command.
 
-###(c) At least one mode of operation and information retrieval that does not require user hearing shall be provided, or support for Assistive Technology used by people who are deaf or hard of hearing shall be provided
+### (c) At least one mode of operation and information retrieval that does not require user hearing shall be provided, or support for Assistive Technology used by people who are deaf or hard of hearing shall be provided
 Supports
 
 * Fiddler does not use audio in any meaningful way.
 
-###(d) Where audio information is important for the use of a product, at least one mode of operation and information retrieval shall be provided in an enhanced auditory fashion, or support for assistive hearing devices shall be provided.
+### (d) Where audio information is important for the use of a product, at least one mode of operation and information retrieval shall be provided in an enhanced auditory fashion, or support for assistive hearing devices shall be provided.
 Supports
 
 * Fiddler does not use audio in any meaningful way.
 
-###(e) At least one mode of operation and information retrieval that does not require user speech shall be provided, or support for Assistive Technology used by people with disabilities shall be provided.
+### (e) At least one mode of operation and information retrieval that does not require user speech shall be provided, or support for Assistive Technology used by people with disabilities shall be provided.
 Not Applicable
 
 * Fiddler does not require the use of speech for any functionality.
 
-###(f) At least one mode of operation and information retrieval that does not require fine motor control or simultaneous actions and that is operable with limited reach and strength shall be provided.
+### (f) At least one mode of operation and information retrieval that does not require fine motor control or simultaneous actions and that is operable with limited reach and strength shall be provided.
 Supports with Exceptions
 
 * Fiddler supports the use of assistive technology such as voice recognition and alternative input devices for people who have reduced motor skills/coordination, with the exceptions listed in the Remarks section.
@@ -343,16 +343,16 @@ Exceptions
 
 * Fiddlers support for voice recognition and alternative input devices can be limited as reason stated in section 1194.21 (a)
 
-#Section 1194.41 Information, Documentation, and Support - Detail
-##Voluntary Product Accessibility Template
+# Section 1194.41 Information, Documentation, and Support - Detail
+## Voluntary Product Accessibility Template
 
-###Section 1194.41 (a) Product Support Documentation provided to end-users shall be made available in alternate formats upon request, at no additional charge.
+### Section 1194.41 (a) Product Support Documentation provided to end-users shall be made available in alternate formats upon request, at no additional charge.
 Supported - [http://www.fiddler2.com/fiddler/help/](http://www.fiddler2.com/fiddler/help/)
 
-###Section 1194.41 (b) End-users shall have access to a description of the accessibility and compatibility features of products in alternate formats or alternate methods upon request, at no additional charge.
+### Section 1194.41 (b) End-users shall have access to a description of the accessibility and compatibility features of products in alternate formats or alternate methods upon request, at no additional charge.
 Supports with Exceptions - [http://www.fiddler2.com/fiddler/help/keyboard.asp](http://www.fiddler2.com/fiddler/help/keyboard.asp) provides keyboard reference
 
-###1194.41 (c) Support services for products shall accommodate the communication needs of end-users with disabilities.
+### 1194.41 (c) Support services for products shall accommodate the communication needs of end-users with disabilities.
 Supports with Exceptions - Support via Web Discussions and email is available in the Product Help menu.
 
-####This document is for informational purposes only. Telerik and Eric Lawrence make no warranties, express implied or statuatory, in this document. Please feel free to send any feedback using the "Contact" link at www.fiddler2.com.
+#### This document is for informational purposes only. Telerik and Eric Lawrence make no warranties, express implied or statuatory, in this document. Please feel free to send any feedback using the "Contact" link at www.fiddler2.com.

--- a/Troubleshoot-Fiddler/ConfigurationSystemError.md
+++ b/Troubleshoot-Fiddler/ConfigurationSystemError.md
@@ -6,11 +6,11 @@ publish: true
 position: 4
 ---
 
-####Fiddler crashes on startup complaining about the "Configuration System":
+#### Fiddler crashes on startup complaining about the "Configuration System":
 
-		
+
 		Sorry, you may have found a bug...
-		
+
 		Fiddler has encountered an unexpected problem. If you believe this is a bug in Fiddler, please copy this message by hitting CTRL+C, and submit a bug report using the Help | Send Feedback menu.
 		Configuration system failed to initialize
 		Source: System.Configuration

--- a/Troubleshoot-Fiddler/NoLocalAuth.md
+++ b/Troubleshoot-Fiddler/NoLocalAuth.md
@@ -6,7 +6,7 @@ publish: true
 position: 3
 ---
 
-####Fiddler's "Automatic Authentication" feature doesn't work when server and client are on the same machine?
+#### Fiddler's "Automatic Authentication" feature doesn't work when server and client are on the same machine?
 If IIS and the client are on the same machine, then a feature called "Loopback protection" is causing the authentication request to fail because your computer recognizes that it is authenticating to itself, and it is unexpected (due to the proxy).
 
 You'll need to set **DisableLoopbackCheck=1** as described here: [http://support.microsoft.com/kb/926642](http://support.microsoft.com/kb/926642)


### PR DESCRIPTION
Stumbled upon this while looking at the [Autoresponder doc on the Knowledgebase](http://docs.telerik.com/fiddler/KnowledgeBase/AutoResponder). The missing space was preventing the headings from being formatted correctly.
```
#This doesn't format correctly
# This does.
```
