### PR TITLE
Small update in Customize Web Sessions List

### DIFF
--- a/knowledge-base/FiddlerScript/CustomizeSessionsList.md
+++ b/knowledge-base/FiddlerScript/CustomizeSessionsList.md
@@ -75,11 +75,12 @@ To customize Fiddler's **Web Sessions List**, [add rules][1] using FiddlerScript
 **Flag all pages in which the server sends a cookie**
 (in **OnBeforeResponse**)
 
-		if (oSession.oResponse.headers.Exists("Set-Cookie") ||
-		  oSession.utilDecodeResponse();
-		  oSession.utilFindInResponse("document.cookie", false)>-1 ||
-		  oSession.utilFindInResponse('HTTP-EQUIV="Set-Cookie"', false)>-1){
-		  oSession["ui-color"]="purple"; 
+		if (oSession.oResponse.headers.Exists("Set-Cookie") {
+		    oSession.utilDecodeResponse();
+		    if (oSession.utilFindInResponse("document.cookie", false)>-1 ||
+		        oSession.utilFindInResponse('HTTP-EQUIV="Set-Cookie"', false)>-1) {
+		        oSession["ui-color"]="purple"; 
+		    }
 		}
 
 


### PR DESCRIPTION
I encountered an error when I tried to use the code described in "Flag all pages in which the server sends a cookie" section.

To fix it and make it clear, I added additional if statement inside existinig one, so the script is working as expected now.