### PR TITLE
fix broken link from quickexec help

### DIFF
--- a/knowledge-base/quickexec.md
+++ b/knowledge-base/quickexec.md
@@ -5,6 +5,7 @@ slug: QuickExec
 publish: true
 position: 1
 res_type: kb
+previous_url: /knowledgebase/quickexec
 ---
 
 ## Environment


### PR DESCRIPTION
fix broken link from quickexec help

related to https://feedback.telerik.com/fiddler/1361307-add-prefs-documentation-to-online-help-for-quickexec