### PR TITLE
docs: Fiddler Classic preferences

### DIFF
--- a/configure-fiddler/advanced-options/fiddler-preferences.md
+++ b/configure-fiddler/advanced-options/fiddler-preferences.md
@@ -67,7 +67,7 @@ prefs remove fiddler.ui.toolbar.mdnsearchurl
 All preference names must follow these rules:
 
 * Names are **not case-sensitive** — `fiddler.UI.Toolbar.Visible` and `fiddler.ui.toolbar.visible` refer to the same preference.
-* Names may only contain ASCII letters (A–Z), digits, dots (`.`), and dashes (`-`).
+* Names may only contain ASCII letters (A–Z), digits, dots (`.`), dashes (`-`), and underscores (`_`).
 * Names must be between 1 and 255 characters long.
 * Preferences with **`ephemeral`** in the name are not saved to or loaded from the registry — they reset on every Fiddler Classic restart.
 * Preferences with **`internal`** in the name cannot be created or modified by extensions or FiddlerScript.

--- a/configure-fiddler/advanced-options/fiddler-preferences.md
+++ b/configure-fiddler/advanced-options/fiddler-preferences.md
@@ -50,7 +50,7 @@ To include a quote character inside a value, escape it with a backslash:
 prefs set fiddler.welcomemsg "I said \"Hello!\""
 ```
 
-When setting a file path, either include trailing whitespace or omit the final backslash to prevent parsing ambiguity:
+When setting a file path, omit the final backslash to prevent parsing ambiguity:
 
 ```sh
 prefs set fiddler.config.path.captures "C:\Work\Captures"

--- a/configure-fiddler/advanced-options/fiddler-preferences.md
+++ b/configure-fiddler/advanced-options/fiddler-preferences.md
@@ -1,6 +1,6 @@
 ---
 title: Configurable Preferences
-description: List of Fiddler CLassic configurable preferences
+description: Learn how to view, set, and manage configurable preferences in Fiddler Classic
 slug: fiddler-classic-preferences
 publish: true
 position: 30
@@ -9,21 +9,113 @@ previous_url: /configure-fiddler/tasks/fiddler-preferences
 
 # Preferences in Fiddler Classic
 
-Fiddler's preferences feature allows you to view and alter many configuration settings.
+Fiddler Classic includes a preferences system for viewing and changing internal configuration settings not exposed through the standard **Tools** > **Options** dialog. Preferences are key-value pairs stored in the Windows Registry and persist across Fiddler Classic sessions.
 
-The following is a partial list of supported preferences in Fiddler; the default value is shown when one exists.
+## Accessing Preferences
+
+### Preferences Tab
+
+Click **View** > **Tabs** > **Preferences** to open a searchable grid of all active preferences. You can add, edit, or remove preferences directly in the grid.
+
+### QuickExec Commands
+
+The [QuickExec box](slug://QuickExec) (the command bar below the session list) accepts `prefs` commands for managing preferences from the keyboard.
+
+#### Browse All Preferences
+
+Type `about:config` in the QuickExec box to open the full editable preferences grid.
+
+#### View Preference Values
+
+```sh
+# Show all current preference values in a message box
+prefs show
+
+# Filter results by a partial name match
+prefs show toolbar
+```
+
+>tip Press `Ctrl+C` inside the result message box to copy the displayed preferences to the clipboard.
+
+#### Set a Preference
+
+```sh
+prefs set fiddler.ui.toolbar.visible True
+prefs set fiddler.config.path.captures "C:\Work\Captures"
+```
+
+To include a quote character inside a value, escape it with a backslash:
+
+```sh
+prefs set fiddler.welcomemsg "I said \"Hello!\""
+```
+
+When setting a file path, either include trailing whitespace or omit the final backslash to prevent parsing ambiguity:
+
+```sh
+prefs set fiddler.config.path.captures "C:\Work\Captures"
+```
+
+#### Remove a Preference
+
+```sh
+prefs remove fiddler.ui.toolbar.mdnsearchurl
+```
+
+## Preference Naming Rules
+
+All preference names must follow these rules:
+
+* Names are **not case-sensitive** — `fiddler.UI.Toolbar.Visible` and `fiddler.ui.toolbar.visible` refer to the same preference.
+* Names may only contain ASCII letters (A–Z), digits, dots (`.`), and dashes (`-`).
+* Names must be between 1 and 255 characters long.
+* Preferences with **`ephemeral`** in the name are not saved to or loaded from the registry — they reset on every Fiddler Classic restart.
+* Preferences with **`internal`** in the name cannot be created or modified by extensions or FiddlerScript.
+
+## Managing Preferences from FiddlerScript or Extensions
+
+Preferences can also be read and written programmatically through `FiddlerApplication.Prefs`, which implements `IFiddlerPreferences`:
+
+```c#
+// Write preferences
+FiddlerApplication.Prefs.SetBoolPref("fiddler.ui.toolbar.visible", true);
+FiddlerApplication.Prefs.SetInt32Pref("fiddler.network.timeouts.dnscache", 300000);
+FiddlerApplication.Prefs.SetStringPref("fiddler.ui.toolbar.mdnsearchurl", "https://example.com/search?q=");
+
+// Read preferences
+bool isVisible = FiddlerApplication.Prefs.GetBoolPref("fiddler.ui.toolbar.visible", true);
+string searchURL = FiddlerApplication.Prefs.GetStringPref("fiddler.ui.toolbar.mdnsearchurl", "");
+```
+
+To watch for preference changes in FiddlerScript, use `WatchPreference`:
+
+```js
+static function OnPrefChange(o: Object, pceA: PrefChangeEventArgs) {
+    FiddlerObject.log(pceA.PrefName + " changed to: " + pceA.ValueString);
+}
+
+static function Main() {
+    FiddlerObject.WatchPreference("fiddler.ui.", OnPrefChange);
+}
+```
+
+For full details on the `IFiddlerPreferences` interface and extension-based watcher patterns, see [Create a Fiddler Classic Extension](slug://CreateExtension).
+
+## Preference Reference
+
+The following is a partial list of preferences with descriptions; the default value is shown where one exists.
 
 Shows error messages when Inspector and Extension related errors are encountered:
 ```bash
 fiddler.debug.extensions.showerrors = "True"
 ```
 
-Shows verbose messages in the Log tab when Fiddler loads Inspector and Extensions:
+Shows verbose messages in the **Log** tab when Fiddler Classic loads inspectors and extensions:
 ```bash
 fiddler.debug.extensions.verbose = "True"
 ```
 
-Controls whether the Fiddler Toolbar is visible:
+Controls whether the Fiddler Classic toolbar is visible:
 ```bash
 fiddler.ui.toolbar.visible = "True"
 ```
@@ -43,161 +135,162 @@ For example, to redirect toolbar searches to a custom internal wiki:
 fiddler.ui.toolbar.mdnsearchurl = "https://wiki.example.com/search?q="
 ```
 
-Controls whether Fiddler disables filters (e.g. Filters tab, Hide Images/Connects, process class filter) after restart (otherwise, the filter state from the last Fiddler session is restored):
+Controls whether Fiddler Classic disables filters (for example, the **Filters** tab, **Hide Images**, **Hide Connects**, and process class filter) after restart (otherwise, the filter state from the last Fiddler Classic session is restored):
 ```bash
 fiddler.filters.resetonrestart = "False"
 ```
 
-String indicating which egressIP to use:
+Specifies the egress IP address to use:
 ```bash
-fiddler.network.egress.IP 131.107.0.111
+fiddler.network.egress.ip 131.107.0.111
 ```
 
-String indicating what hostname to use when registering as the system proxy. Should be 127.0.0.1 (default), localhost, the machine's name, or the machine's IP address.
+Specifies the hostname to use when registering as the system proxy. Accepted values: `127.0.0.1` (default), `localhost`, the machine name, or the machine's IP address.
 ```bash
 fiddler.network.proxy.registrationhostname = "127.0.0.1"
 ```
 
-Controls whether Fiddler will request a client certificate from the client application any time a HTTPS connection is made; this is mostly useful for testing whether the client can properly handle attaching such a certificate. Note: You must restart Fiddler after setting this option for the change to take effect.
+Controls whether Fiddler Classic requests a client certificate from the client application any time an HTTPS connection is made. This is useful for testing whether the client handles attaching such a certificate.
+
+>note You must restart Fiddler Classic after setting this option for the change to take effect.
 ```bash
 fiddler.network.https.requestclientcertificate = "False"
 ```
 
-Controls the Rules > Remove all Encodings rule:
+Controls the **Rules** > **Remove All Encodings** rule:
 ```bash
 fiddler.ui.rules.removeencoding = "False"
 ```
 
-Controls the Rules > Hide Connects rule:
+Controls the **Rules** > **Hide Connects** rule:
 ```bash
 fiddler.ui.rules.hideconnects = "False"
 ```
 
 
-Controls the Rules > Hide Images rule:
+Controls the **Rules** > **Hide Images** rule:
 ```bash
 fiddler.ui.rules.hideimages = "False"
 ```
 
-Set to "True" to cause Fiddler to abort a download if streaming the response to the client and the client aborts the connection to Fiddler:
+When set to `True`, Fiddler Classic aborts a download if it is streaming the response to the client and the client closes the connection:
 ```bash
 fiddler.network.streaming.abortifclientaborts = "False"
 ```
 
-Set to "True" to cause Fiddler to "forget" received bytes if they are streamed to the client. Similar to the SessionFlag 
-log-drop-response-body, but forgetting occurs during streaming rather than upon response completion:
+When set to `True`, Fiddler Classic discards received bytes as they are streamed to the client — similar to the `log-drop-response-body` session flag, but the discarding occurs during streaming rather than after the response completes:
 ```bash
 fiddler.network.streaming.forgetstreameddata = "False"
 ```
 
-Number of milliseconds Fiddler should wait for a request from the client on a new client connection:
+Number of milliseconds Fiddler Classic waits for a request from the client on a new connection (initial timeout):
 ```bash
 fiddler.network.timeouts.clientpipe.receive.initial = 60000
 ```
 
-Number of milliseconds Fiddler should wait for a request from the client on a new client connection.
+Number of milliseconds Fiddler Classic waits for a request from the client on a reused keep-alive connection:
 ```bash
 fiddler.network.timeouts.clientpipe.receive.reuse = 30000
 ```
 
-Number of milliseconds Fiddler should keep a DNS cache entry in its cache:
+Number of milliseconds Fiddler Classic keeps a DNS cache entry:
 ```bash
 fiddler.network.timeouts.dnscache = 150000
 ```
 
-When CTRL+X is hit, keep sessions that are either in progress, or marked (at a breakpoint, or with a comment, or with a mark color set)
+When `Ctrl+X` is pressed, Fiddler Classic keeps sessions that are in progress or marked (at a breakpoint, with a comment, or with a color mark):
 ```bash
-fiddler.ui.CtrlX.KeepMarked = True
+fiddler.ui.ctrlx.keepmarked = True
 ```
 
-Force Fiddler to always use the RAW request inspector when double-clicking or hitting ENTER on a session:
+Forces Fiddler Classic to always use the **Raw** request inspector when you double-click or press `Enter` on a session:
 ```bash
 fiddler.ui.inspectors.request.alwaysuse = "Raw"
 ```
 
-Force Fiddler to always use the SyntaxView response inspector when double-clicking or hitting ENTER on a session:
+Forces Fiddler Classic to always use the **SyntaxView** response inspector when you double-click or press `Enter` on a session:
 ```bash
 fiddler.ui.inspectors.response.alwaysuse = "SyntaxView"
 ```
 
-** FULL LIST of all preferences in Fiddler Classic**
+### Full Preference List
 
 ```bash
 addons.ericlaw.hosts.enabled
-addons.ImageBloat.EmbedAsText
-addons.ImageBloat.KeepOriginalResponse
+addons.imagebloat.embedastext
+addons.imagebloat.keeporiginalresponse
 experiment.nodoublebuffer
-ext.ContentBlocker.BlockHosts
-ext.ContentBlocker.BlockPathsByHeuristic
-ext.ContentBlocker.FlashBlockAlways
-ext.ContentBlocker.FlashBlockXDomain
-ext.ContentBlocker.HideBlocked
-ext.ContentBlocker.ShortcircuitRedirects
-extensions.AnyWHERE.LastLocation
+ext.contentblocker.blockhosts
+ext.contentblocker.blockpathsbyheuristic
+ext.contentblocker.flashblockalways
+ext.contentblocker.flashblockxdomain
+ext.contentblocker.hideblocked
+ext.contentblocker.shortcircuitredirects
+extensions.anywhere.lastlocation
 extensions.tagcookies.enabled
-extensions.tagcookies.EnforceP3PValidity
-fiddler.auth.SPNIncludesPort
-fiddler.auth.SPNMode
+extensions.tagcookies.enforcep3pvalidity
+fiddler.auth.spnincludesport
+fiddler.auth.spnmode
 fiddler.certmaker.assembly
-fiddler.certmaker.bc.AddClientAuthEKU
-fiddler.certmaker.bc.AddCRL
-fiddler.certmaker.bc.AddEVPolicyOID
+fiddler.certmaker.bc.addclientautheku
+fiddler.certmaker.bc.addcrl
+fiddler.certmaker.bc.addevpolicyoid
 fiddler.certmaker.bc.cert
-fiddler.certmaker.bc.CRLURL
-fiddler.certmaker.bc.Debug
-fiddler.certmaker.bc.DoDummyEncrypt
-fiddler.certmaker.bc.EE.CreatedDaysAgo
-fiddler.certmaker.bc.EE.CriticalAKID
-fiddler.certmaker.bc.EE.CriticalBasicConstraints
-fiddler.certmaker.bc.EE.CriticalEKU
-fiddler.certmaker.bc.EE.SetAKID
-fiddler.certmaker.bc.EE.SigAlg
-fiddler.certmaker.bc.EE.YearsValid
-fiddler.certmaker.bc.EmitEECertFile
-fiddler.certmaker.bc.EmitRootCertFile
+fiddler.certmaker.bc.crlurl
+fiddler.certmaker.bc.debug
+fiddler.certmaker.bc.dodummyencrypt
+fiddler.certmaker.bc.ee.createddaysago
+fiddler.certmaker.bc.ee.criticalakid
+fiddler.certmaker.bc.ee.criticalbasicconstraints
+fiddler.certmaker.bc.ee.criticaleku
+fiddler.certmaker.bc.ee.setakid
+fiddler.certmaker.bc.ee.sigalg
+fiddler.certmaker.bc.ee.yearsvalid
+fiddler.certmaker.bc.emiteecertfile
+fiddler.certmaker.bc.emitrootcertfile
 fiddler.certmaker.bc.key
-fiddler.certmaker.bc.KeyContainerName
-fiddler.certmaker.bc.KeyLength
-fiddler.certmaker.bc.KeyProviderType
-fiddler.certmaker.bc.LogPrivateKeys
-fiddler.certmaker.bc.ParallelTimeout
-fiddler.certmaker.bc.ReusePrivateKeys
-fiddler.certmaker.bc.ReuseRoot
-fiddler.certmaker.bc.ReuseRootKeysForEE
-fiddler.certmaker.bc.Root.CriticalAKID
-fiddler.certmaker.bc.Root.CriticalBasicConstraints
-fiddler.certmaker.bc.Root.CriticalKeyUsage
-fiddler.certmaker.bc.Root.CriticalSKID
-fiddler.certmaker.bc.Root.SetAKID
-fiddler.certmaker.bc.Root.SigAlg
-fiddler.certmaker.bc.Root.YearsValid
-fiddler.certmaker.bc.RootCN
-fiddler.certmaker.bc.RootFriendly
-fiddler.certmaker.bc.RootKeyLength
-fiddler.certmaker.bc.UseMachineKeyStore
-fiddler.certmaker.ce.EE.KeyLength
-fiddler.certmaker.ce.EE.SigAlg
-fiddler.certmaker.ce.Root.KeyLength
-fiddler.certmaker.ce.Root.SigAlg
-fiddler.CertMaker.CleanupServerCertsOnExit
-fiddler.certmaker.DateFormatString
-fiddler.certmaker.Debug
-fiddler.certmaker.EE.extraparams
-fiddler.certmaker.EE.SigAlg
-fiddler.certmaker.GraceDays
-fiddler.CertMaker.OfferMachineTrust
-fiddler.certmaker.PreferCertEnroll
-fiddler.certmaker.Root.extraparams
-fiddler.certmaker.Root.SigAlg
-fiddler.certmaker.ValidDays
+fiddler.certmaker.bc.keycontainername
+fiddler.certmaker.bc.keylength
+fiddler.certmaker.bc.keyprovidertype
+fiddler.certmaker.bc.logprivatekeys
+fiddler.certmaker.bc.paralleltimeout
+fiddler.certmaker.bc.reuseprivatekeys
+fiddler.certmaker.bc.reuseroot
+fiddler.certmaker.bc.reuserootkeysforee
+fiddler.certmaker.bc.root.criticalakid
+fiddler.certmaker.bc.root.criticalbasicconstraints
+fiddler.certmaker.bc.root.criticalkeyusage
+fiddler.certmaker.bc.root.criticalskid
+fiddler.certmaker.bc.root.setakid
+fiddler.certmaker.bc.root.sigalg
+fiddler.certmaker.bc.root.yearsvalid
+fiddler.certmaker.bc.rootcn
+fiddler.certmaker.bc.rootfriendly
+fiddler.certmaker.bc.rootkeylength
+fiddler.certmaker.bc.usemachinekeystore
+fiddler.certmaker.ce.ee.keylength
+fiddler.certmaker.ce.ee.sigalg
+fiddler.certmaker.ce.root.keylength
+fiddler.certmaker.ce.root.sigalg
+fiddler.certmaker.cleanupservercertsonexit
+fiddler.certmaker.dateformatstring
+fiddler.certmaker.debug
+fiddler.certmaker.ee.extraparams
+fiddler.certmaker.ee.sigalg
+fiddler.certmaker.gracedays
+fiddler.certmaker.offermachinetrust
+fiddler.certmaker.prefercertenroll
+fiddler.certmaker.root.extraparams
+fiddler.certmaker.root.sigalg
+fiddler.certmaker.validdays
 fiddler.composer.autoauth
-fiddler.composer.AutoAuthCreds
+fiddler.composer.autoauthcreds
 fiddler.composer.followredirects
 fiddler.composer.followredirects.max
-fiddler.composer.history.LogRequests
+fiddler.composer.history.logrequests
 fiddler.composer.history.removeduplicates
-fiddler.composer.history.SaveOnExit
-fiddler.composer.HTTPSProxyBasicCreds
+fiddler.composer.history.saveonexit
+fiddler.composer.httpsproxybasiccreds
 fiddler.composer.inspectsession
 fiddler.config.path.captures
 fiddler.config.path.defaultclientcert
@@ -206,104 +299,104 @@ fiddler.config.path.explorer
 fiddler.config.path.lsof
 fiddler.config.path.makecert
 fiddler.config.path.texteditor
-fiddler.config.path.Tools
+fiddler.config.path.tools
 fiddler.config.path.webtestexport.plugins
 fiddler.debug.extensions.verbose
-fiddler.differ.DecodeFirst
-fiddler.differ.Params
-fiddler.differ.ParamsAlt
+fiddler.differ.decodefirst
+fiddler.differ.params
+fiddler.differ.paramsalt
 fiddler.differ.ultradiff
 fiddler.echoservice.enabled
-fiddler.ephemeral.autoresponder.LastTestURI
-fiddler.exporters.cURL.DefaultOptions
-fiddler.exporters.RawFiles.OpenFolder
-fiddler.exporters.RawFiles.RecreateStructure
-fiddler.exporters.RawFiles.SkipNon200
-fiddler.extensions.AutoSave.Password
-fiddler.extensions.HTTPSNotary.Enabled
-fiddler.extensions.HTTPSNotary.IgnoreHosts
-fiddler.extensions.HTTPSNotary.IgnoreSSLPolicyErrors
-fiddler.extensions.HTTPSNotary.LogVerbose
-fiddler.extensions.HTTPSNotary.TimeoutMS
-fiddler.extensions.JSFormat.AutoFormat
-fiddler.extensions.JSFormat.BackColor
+fiddler.ephemeral.autoresponder.lasttesturi
+fiddler.exporters.curl.defaultoptions
+fiddler.exporters.rawfiles.openfolder
+fiddler.exporters.rawfiles.recreatestructure
+fiddler.exporters.rawfiles.skipnon200
+fiddler.extensions.autosave.password
+fiddler.extensions.httpsnotary.enabled
+fiddler.extensions.httpsnotary.ignorehosts
+fiddler.extensions.httpsnotary.ignoresslpolicyerrors
+fiddler.extensions.httpsnotary.logverbose
+fiddler.extensions.httpsnotary.timeoutms
+fiddler.extensions.jsformat.autoformat
+fiddler.extensions.jsformat.backcolor
 fiddler.filters.ephemeral.debugmode
-fiddler.filters.ResetOnRestart
+fiddler.filters.resetonrestart
 fiddler.find.ephemeral.lastsearchmarkcolor
-fiddler.ftp.AlwaysDemandCredentials
-fiddler.ftp.UseBinary
-fiddler.ftp.UsePassive
-fiddler.gallery.DisplayLimit
-fiddler.gallery.FixedHeight
-fiddler.gallery.MinSizeK
-fiddler.Gallery.PicturePile.BackColor
-fiddler.Gallery.PicturePile.Interval
-fiddler.Gallery.Slideshow.BackColor
-fiddler.Gallery.Slideshow.CommentBackColor
-fiddler.Gallery.Slideshow.CommentForeColor
-fiddler.gallery.ThumbSize
-fiddler.importers.PacketCapture.debug
-fiddler.importers.PacketCapture.verbose
-fiddler.importexport.HTTPArchiveJSON.MaxBinaryBodyLength
-fiddler.importexport.HTTPArchiveJSON.MaxTextBodyLength
-fiddler.inspectors.headers.AutoSizeRequestLine
+fiddler.ftp.alwaysdemandcredentials
+fiddler.ftp.usebinary
+fiddler.ftp.usepassive
+fiddler.gallery.displaylimit
+fiddler.gallery.fixedheight
+fiddler.gallery.minsizek
+fiddler.gallery.picturepile.backcolor
+fiddler.gallery.picturepile.interval
+fiddler.gallery.slideshow.backcolor
+fiddler.gallery.slideshow.commentbackcolor
+fiddler.gallery.slideshow.commentforecolor
+fiddler.gallery.thumbsize
+fiddler.importers.packetcapture.debug
+fiddler.importers.packetcapture.verbose
+fiddler.importexport.httparchivejson.maxbinarybodylength
+fiddler.importexport.httparchivejson.maxtextbodylength
+fiddler.inspectors.headers.autosizerequestline
 fiddler.inspectors.hexview.bytesperline
 fiddler.inspectors.hexview.showoffsets
-fiddler.inspectors.HideList
-fiddler.inspectors.images.AlertOnGeoLoc
-fiddler.inspectors.images.EditedReloadDelay
-fiddler.inspectors.images.EditorPath
-fiddler.inspectors.images.MapURI
+fiddler.inspectors.hidelist
+fiddler.inspectors.images.alertongeoloc
+fiddler.inspectors.images.editedreloaddelay
+fiddler.inspectors.images.editorpath
+fiddler.inspectors.images.mapuri
 fiddler.inspectors.images.textwidth
 fiddler.inspectors.images.viewmode
 fiddler.inspectors.request.raw.truncatebinaryat
 fiddler.inspectors.request.raw.truncatetextat
-fiddler.inspectors.RequestHexView.ShowHeaders
-fiddler.inspectors.response.AdvertiseFSE
-fiddler.inspectors.response.AdvertiseSyntaxView
+fiddler.inspectors.requesthexview.showheaders
+fiddler.inspectors.response.advertisefse
+fiddler.inspectors.response.advertisesyntaxview
 fiddler.inspectors.response.raw.truncatebinaryat
 fiddler.inspectors.response.raw.truncatetextat
 fiddler.inspectors.response.syntaxview.wordwrap
-fiddler.inspectors.response.WebView.AutoPlay
-fiddler.inspectors.ResponseHexView.ShowHeaders
-fiddler.inspectors.WebForms.AssumeURLEncoded
-fiddler.Lint.HTTP
-fiddler.log.DropMessagesUnlessActive
-fiddler.memory.DropIfOver
+fiddler.inspectors.response.webview.autoplay
+fiddler.inspectors.responsehexview.showheaders
+fiddler.inspectors.webforms.assumeurlencoded
+fiddler.lint.http
+fiddler.log.dropmessagesunlessactive
+fiddler.memory.dropifover
 fiddler.network.auth.reusemode
 fiddler.network.dns.fallback
-fiddler.network.dns.MaxAddressCount
-fiddler.network.dns.ResolveOnionHosts
-fiddler.network.FixRequestContentLength
-fiddler.network.gateway.DetermineInProcess
+fiddler.network.dns.maxaddresscount
+fiddler.network.dns.resolveonionhosts
+fiddler.network.fixrequestcontentlength
+fiddler.network.gateway.determineinprocess
 fiddler.network.gateway.exceptions
 fiddler.network.gateway.proxies
-fiddler.network.gateway.UseFailedAutoProxy
+fiddler.network.gateway.usefailedautoproxy
 fiddler.network.https.blindtunnelifcertunobtainable
 fiddler.network.https.cacheclientcert
 fiddler.network.https.checkcertificaterevocation
 fiddler.network.https.clientcertificate.ephemeral.prompt-for-missing
-fiddler.network.https.NoDecryptionHosts
+fiddler.network.https.nodecryptionhosts
 fiddler.network.https.requestclientcertificate
-fiddler.network.https.SetCNFromSNI
+fiddler.network.https.setcnfromsni
 fiddler.network.https.storeservercertchain
-fiddler.network.https.SupportedClientProtocolVersions
-fiddler.network.https.SupportedServerProtocolVersions
+fiddler.network.https.supportedclientprotocolversions
+fiddler.network.https.supportedserverprotocolversions
 fiddler.network.https.validateclientcert
 fiddler.network.leakhttp1xx
-fiddler.network.proxy.RegistrationHostName
-fiddler.network.RejectIncompleteRequests
-fiddler.network.SetHostHeaderFromURL
-fiddler.network.sockets.Client_SO_RCVBUF
-fiddler.network.sockets.Client_SO_SNDBUF
-fiddler.network.sockets.ClientReadBufferSize
-fiddler.network.sockets.Server_SO_RCVBUF
-fiddler.network.sockets.Server_SO_SNDBUF
-fiddler.network.sockets.ServerReadBufferSize
+fiddler.network.proxy.registrationhostname
+fiddler.network.rejectincompleterequests
+fiddler.network.sethostheaderfromurl
+fiddler.network.sockets.client_so_rcvbuf
+fiddler.network.sockets.client_so_sndbuf
+fiddler.network.sockets.clientreadbuffersize
+fiddler.network.sockets.server_so_rcvbuf
+fiddler.network.sockets.server_so_sndbuf
+fiddler.network.sockets.serverreadbuffersize
 fiddler.network.streaming.abortifclientaborts
 fiddler.network.streaming.abortorphanstreams
-fiddler.network.streaming.AutoStreamByMIME
-fiddler.network.streaming.ForgetStreamedData
+fiddler.network.streaming.autostreambymime
+fiddler.network.streaming.forgetstreameddata
 fiddler.network.timeouts.clientpipe.receive.initial
 fiddler.network.timeouts.clientpipe.receive.reuse
 fiddler.network.timeouts.dnscache
@@ -313,91 +406,97 @@ fiddler.network.timeouts.serverpipe.reuse
 fiddler.network.timeouts.serverpipe.send.initial
 fiddler.network.timeouts.serverpipe.send.reuse
 fiddler.network.timeouts.serverpipe.watchdoginterval
-fiddler.ProcessInfo.DecorateWithAppName
+fiddler.processinfo.decoratewithappname
 fiddler.proxy.creds
-fiddler.proxy.IgnoreGatewayOverrideIfUnreachable
+fiddler.proxy.ignoregatewayoverrideifunreachable
 fiddler.proxy.pacfile.text
 fiddler.proxy.pacfile.usefileprotocol
-fiddler.proxy.WarnAboutAppContainers
-fiddler.proxy.WarnIfElevationRequired
-fiddler.proxy.WatchRegistry
-fiddler.proxy.WorkaroundBuggyWinShutdown
-fiddler.QuickExec.autocomplete
-fiddler.QuickExec.KeepHistory
+fiddler.proxy.warnaboutappcontainers
+fiddler.proxy.warnifelevationrequired
+fiddler.proxy.watchregistry
+fiddler.proxy.workaroundbuggywinshutdown
+fiddler.quickexec.autocomplete
+fiddler.quickexec.keephistory
 fiddler.reissue.autoauth
 fiddler.reissue.autoredircount
-fiddler.saz.AddUIShortcuts
-fiddler.saz.AES.Use256Bit
-fiddler.saz.ClearCaches
-fiddler.saz.PrivacyNoticeShown
-fiddler.saz.ReloadIDAsFlag
-fiddler.SAZ.UseMemoryCache
-fiddler.screenshot.DelayMS
-fiddler.script.AutoRef
-fiddler.script.CompileToFilename
+fiddler.saz.adduishortcuts
+fiddler.saz.aes.use256bit
+fiddler.saz.clearcaches
+fiddler.saz.privacynoticeshown
+fiddler.saz.reloadidasflag
+fiddler.saz.usememorycache
+fiddler.screenshot.delayms
+fiddler.script.autoref
+fiddler.script.compiletofilename
 fiddler.script.delaycreate
-fiddler.script.GenerateDebugInfo
-fiddler.script.LibPath
-fiddler.session.prependIDtosuggestedfilename
-fiddler.sounds.Countdown
-fiddler.sounds.Gallery.SlideShowAdvance
-fiddler.sounds.Screenshot
-fiddler.sounds.ScriptCompile
-fiddler.sounds.ScriptError
-fiddler.textwizard.InputEncoding
-fiddler.textwizard.OutputEncoding
-fiddler.threads.minIO
+fiddler.script.generatedebuginfo
+fiddler.script.libpath
+fiddler.session.prependidtosuggestedfilename
+fiddler.sounds.countdown
+fiddler.sounds.gallery.slideshowadvance
+fiddler.sounds.screenshot
+fiddler.sounds.scriptcompile
+fiddler.sounds.scripterror
+fiddler.textwizard.inputencoding
+fiddler.textwizard.outputencoding
+fiddler.threads.minio
 fiddler.threads.minworker
 fiddler.timeline.mode
-fiddler.timeline.SessionLimit
-fiddler.transfomer.ChunkCount
-fiddler.ui.AutoRefreshItemCountLimit
-fiddler.ui.Colors.AutoResponded
-fiddler.ui.Colors.ColumnDuplicate
-fiddler.ui.Colors.ImageBloat
-fiddler.ui.Colors.ImageBloatMortar
-fiddler.ui.Colors.LoadedFromSAZ
-fiddler.ui.Colors.QuickExec
-fiddler.ui.Colors.QuickExecText
-fiddler.ui.CtrlX.KeepMarked
-fiddler.ui.CtrlX.PromptIfMoreThan
+fiddler.timeline.sessionlimit
+fiddler.transfomer.chunkcount
+fiddler.ui.autorefreshitemcountlimit
+fiddler.ui.colors.autoresponded
+fiddler.ui.colors.columnduplicate
+fiddler.ui.colors.imagebloat
+fiddler.ui.colors.imagebloatmortar
+fiddler.ui.colors.loadedfromsaz
+fiddler.ui.colors.quickexec
+fiddler.ui.colors.quickexectext
+fiddler.ui.ctrlx.keepmarked
+fiddler.ui.ctrlx.promptifmorethan
 fiddler.ui.ephemeral.rules.breakonrequest
 fiddler.ui.ephemeral.rules.breakonresponse
 fiddler.ui.ephemeral.rules.forcegzip
 fiddler.ui.ephemeral.rules.requireproxyauth
-fiddler.ui.ExplorerStyle
+fiddler.ui.explorerstyle
 fiddler.ui.fixedfont.face
 fiddler.ui.font.face
-fiddler.ui.httperror.Height
-fiddler.ui.httperror.Left
-fiddler.ui.httperror.Top
-fiddler.ui.httperror.Width
+fiddler.ui.httperror.height
+fiddler.ui.httperror.left
+fiddler.ui.httperror.top
+fiddler.ui.httperror.width
 fiddler.ui.inspectors.request.alwaysuse
 fiddler.ui.inspectors.response.alwaysuse
 fiddler.ui.lastview
 fiddler.ui.layout.mode
-fiddler.ui.MaskPasswords
+fiddler.ui.maskpasswords
 fiddler.ui.menus.book.visible
 fiddler.ui.mru.max
-fiddler.ui.overrideIcon
-fiddler.ui.ReporterUpdateInterval
+fiddler.ui.overrideicon
+fiddler.ui.reporterupdateinterval
 fiddler.ui.rules.bufferresponses
 fiddler.ui.rules.hideconnects
 fiddler.ui.rules.hideimages
 fiddler.ui.rules.keeponly
 fiddler.ui.rules.removeencoding
 fiddler.ui.sessionlist.updateinterval
-fiddler.ui.toolbar.BrowserList
+fiddler.ui.toolbar.browserlist
 fiddler.ui.toolbar.mdnsearchcue
 fiddler.ui.toolbar.mdnsearchurl
-fiddler.ui.toolbar.ShowLabels
+fiddler.ui.toolbar.showlabels
 fiddler.ui.toolbar.visible
-fiddler.ui.WizardColumnSet
-fiddler.updater.CheckFreshness
-fiddler.updater.LastBegged
-fiddler.updater.OfferBetaBuilds
-fiddler.websocket.ParseMessages
+fiddler.ui.wizardcolumnset
+fiddler.updater.checkfreshness
+fiddler.updater.lastbegged
+fiddler.updater.offerbetabuilds
+fiddler.websocket.parsemessages
 fiddler.welcomemsg
-inspectors.pdfview.SpeakRate
-inspectors.webview.SpeakRate
+inspectors.pdfview.speakrate
+inspectors.webview.speakrate
 ```
+
+## See Also
+
+- [QuickExec Reference](slug://QuickExec)
+- [Create a Fiddler Classic Extension](slug://CreateExtension)
+- [Options UI Reference](slug://options-ui)


### PR DESCRIPTION
## Summary

This PR updates the Fiddler Classic documentation across several areas.

### Preferences article ([fiddler-preferences.md](configure-fiddler/advanced-options/fiddler-preferences.md))

Significant rewrite of the article to add a proper how-to introduction and apply style guide rules throughout.

**New content:**
- **Accessing Preferences** section — documents both the GUI route (**View** > **Tabs** > **Preferences**) and the `about:config` QuickExec shortcut
- **QuickExec Commands** section — `prefs show`, `prefs show <filter>`, `prefs set`, and `prefs remove` with examples including path and quote-escaping edge cases
- **Preference Naming Rules** section — case-insensitivity, allowed characters, length limits, `ephemeral` and `internal` special behaviors
- **Managing Preferences from FiddlerScript or Extensions** — brief `FiddlerApplication.Prefs` API examples and a `WatchPreference` FiddlerScript snippet, with a link to the extension docs
- **See Also** section

**New preferences documented:**
- `fiddler.ui.toolbar.MDNSearchCue` — controls the toolbar search-box placeholder text
- `fiddler.ui.toolbar.MDNSearchURL` — controls the toolbar search target URL (can redirect away from MDN)

**Style guide fixes:**
- All preference names normalized to lowercase throughout (names are case-insensitive per the spec)
- Menu sequences use correct bold + plain `>` format (**Tools** > **Options**)
- Keyboard shortcuts use monospace Initial Caps (`Ctrl+C`, `Ctrl+X`, `Enter`)
- `e.g.` replaced with "for example,"
- `Note:` inline replaced with `>note` callout
- "should" replaced with present-simple tense
- "String indicating" descriptions rewritten as active "Specifies"
- "Set to True to cause" rewritten as "When set to `True`, …"
- "Force Fiddler" → "Forces Fiddler Classic" (consistent third person)
- UI elements bolded: **Raw**, **SyntaxView**, **Log** tab, **Filters** tab, **Hide Images**, **Hide Connects**
- Bold pseudo-headings promoted to proper `####` subheadings with Title Case
- Duplicate `clientpipe.receive` description differentiated (initial timeout vs. keep-alive reuse)
- Fixed malformed `** FULL LIST**` heading; promoted to `### Full Preference List`
- Fixed frontmatter description typo ("CLassic" → "Classic")

---

### ZSTD support ([observe-traffic/viewsessioncontent.md](observe-traffic/viewsessioncontent.md))

Added **Supported Content Encodings** section documenting that Fiddler Classic natively decompresses `gzip`, `deflate`, `br` (Brotli), and `zstd` (Zstandard). The zstd entry notes that Chrome and Edge advertise it by default and that Fiddler Classic handles it transparently.

Closes feedback item: https://feedback.telerik.com/fiddler/1454276-decrypt-zstandard-zstd-encoded-requests

---

### Commercial use notice ([introduction.md](introduction.md), [configure-fiddler/installfiddler.md](configure-fiddler/installfiddler.md))

Added `>important` callouts to both the intro page and the install page announcing that:
- As of **August 3, 2026**, Fiddler Classic is licensed for **non-commercial use only**
- The commercial transition deadline is **September 17, 2026**
- Commercial use requires [Fiddler Everywhere](https://telerik.com/fiddler/fiddler-everywhere)
- Links to the [Fiddler Classic License Agreement](https://www.telerik.com/purchase/license-agreement/fiddler)

## Files Changed

| File | Change |
|------|--------|
| `configure-fiddler/advanced-options/fiddler-preferences.md` | Rewrite with how-to intro, new preferences, style guide fixes, lowercase normalization |
| `observe-traffic/viewsessioncontent.md` | Added Supported Content Encodings section (ZSTD) |
| `introduction.md` | Added commercial use transition notice |
| `configure-fiddler/installfiddler.md` | Added commercial use transition notice |